### PR TITLE
Update snake_case reference to be correct spelling

### DIFF
--- a/1.x/configuration/the-basics.md
+++ b/1.x/configuration/the-basics.md
@@ -89,7 +89,7 @@ ls:
         .js: PascalCase
 
     src/templates:
-        .js: snake-case
+        .js: snake_case
 ```
 
 :::warning Keep in mind


### PR DESCRIPTION
Fixes typo mentioned in https://github.com/loeffel-io/ls-lint/issues/28

[From search](https://github.com/ls-lint/docs/search?q=snake-case&unscoped_q=snake-case), it seems like the only case.