### PR TITLE
Update installation.md to include --save-dev

### DIFF
--- a/2.3/getting-started/installation.md
+++ b/2.3/getting-started/installation.md
@@ -32,7 +32,7 @@ ls-lint-windows-amd64.exe
 
 ```bash
 npm install -g @ls-lint/ls-lint@v2.3.0 # global
-npm install @ls-lint/ls-lint@v2.3.0 # local
+npm install --save-dev @ls-lint/ls-lint@v2.3.0 # local
 ```
 
 ### Run


### PR DESCRIPTION
Since ls-lint is just used during development to check folder and file naming, it doesn’t need to be included in production builds. Installing it with --save-dev helps keep things tidy and makes it clear to others that it’s only needed while developing.