### PR TITLE
fix: typo in exists example code

### DIFF
--- a/2.3/configuration/the-rules.md
+++ b/2.3/configuration/the-rules.md
@@ -119,7 +119,7 @@ ls:
 ```yaml
 ls:
   components/{auth,account}:
-    dir: exists:1
+    .dir: exists:1
     .*: ...
 
     "*":


### PR DESCRIPTION
Fix: https://github.com/ls-lint/docs/issues/43

Fixed a typo in the exists example code.