### PR TITLE
fix: typo in blog exists-rules example code

### DIFF
--- a/blog/announcements/v2.3.0.md
+++ b/blog/announcements/v2.3.0.md
@@ -131,7 +131,7 @@ ls:
 ```yaml
 ls:
   components/{auth,account}:
-    dir: exists
+    .dir: exists
     .*: ...
 
     "*":


### PR DESCRIPTION
Fix: https://github.com/ls-lint/docs/issues/43

Fixed a typo in the blog exists-rules example code.